### PR TITLE
Fix javadocs problems so documentation can be automatically generated

### DIFF
--- a/src/ispd/arquivo/xml/IconicoXML.java
+++ b/src/ispd/arquivo/xml/IconicoXML.java
@@ -11,12 +11,12 @@ import ispd.gui.PickModelTypeDialog;
 import ispd.gui.iconico.Edge;
 import ispd.gui.iconico.Vertex;
 import ispd.gui.iconico.grade.VirtualMachine;
-import ispd.motor.workload.impl.CollectionWorkloadGenerator;
-import ispd.motor.workload.impl.TraceFileWorkloadGenerator;
-import ispd.motor.workload.impl.GlobalWorkloadGenerator;
-import ispd.motor.workload.WorkloadGenerator;
 import ispd.motor.filas.RedeDeFilas;
 import ispd.motor.filas.RedeDeFilasCloud;
+import ispd.motor.workload.WorkloadGenerator;
+import ispd.motor.workload.impl.CollectionWorkloadGenerator;
+import ispd.motor.workload.impl.GlobalWorkloadGenerator;
+import ispd.motor.workload.impl.TraceFileWorkloadGenerator;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -157,7 +157,8 @@ public class IconicoXML {
      * Get load configuration containing in the iconic model present in the
      * {@link Document}
      *
-     * @return {@link WorkloadGenerator} with load configuration from the model, if
+     * @return {@link WorkloadGenerator} with load configuration from the
+     * model, if
      * a valid one is present, {@code null} otherwise
      * @see LoadBuilder
      * @see TraceFileWorkloadGenerator
@@ -718,9 +719,8 @@ public class IconicoXML {
     }
 
     /**
-     * Add a random load to the current model being built.
-     *
-     * @apiNote This method just be called at most <b>once</b>> per instance,
+     * Add a random load to the current model being built.<br>
+     * This method should be called at most <b>once</b> per instance,
      * and not mixed with calls to
      * {@link #setLoadTrace(String, int, String)} or
      * {@link #addLoadNo(String, String, String, Integer, Double, Double, Double, Double)}
@@ -767,10 +767,9 @@ public class IconicoXML {
     }
 
     /**
-     * Add a per-node load to the current model being built.
-     *
-     * @apiNote This method may be called more than once per instance,
-     * however it should be mixed with calls to
+     * Add a per-node load to the current model being built.<br>
+     * This method may be called more than once per instance, however it
+     * should be mixed with calls to
      * {@link #setLoadTrace(String, int, String)} or
      * {@link #setLoadRandom(int, int, double, double, double, double, double, double, double, double)}.
      */
@@ -803,10 +802,9 @@ public class IconicoXML {
     }
 
     /**
-     * Add a trace load to the current model being built.
-     *
-     * @apiNote This method just be called at most <b>once</b>> per instance,
-     * and not mixed with calls to
+     * Add a trace load to the current model being built.<br>
+     * This method just be called at most <b>once</b>> per instance, and not
+     * mixed with calls to
      * {@link #setLoadRandom(int, int, double, double, double, double, double, double, double, double)} or
      * {@link #addLoadNo(String, String, String, Integer, Double, Double, Double, Double)}
      */

--- a/src/ispd/escalonador/Escalonador.java
+++ b/src/ispd/escalonador/Escalonador.java
@@ -46,19 +46,6 @@ import ispd.motor.filas.servidores.CentroServico;
 import ispd.motor.metricas.MetricasUsuarios;
 import java.util.List;
 
-/**
- * Classe abstrata ue implementa os escalonadores.
- * 
- * lista de atributos:
- * 
- *  protected List<CS_Processamento> escravos : Lista de escravos para quem o escalonador dele distribuir tarefas
- *  protected List<List> filaEscravo : Lista que contem informações sobre cada escravo, utilizado em políticas dinâmicas.
- *  protected List<Tarefa> tarefas : Lista de tarefas para serem distribuídas entre os escravos
- *  protected MetricasUsuarios metricaUsuarios : Objeto que calcula métricas sobre o escalonamento para os usuários
- *  protected Mestre mestre : 
- 
- * @author Diogo Tavares
- */
 public abstract class Escalonador {
     //Atributos
     protected List<CS_Processamento> escravos;

--- a/src/ispd/gui/iconico/Icon.java
+++ b/src/ispd/gui/iconico/Icon.java
@@ -15,16 +15,12 @@ public interface Icon {
     /**
      * Returns {@code true} if this icon is contained in an area near
      * the given X and Y coordinates. Otherwise, {@code false} is
-     * returned.
-     *
-     * @apiNote
+     * returned.<br>
      * This method is often used to detect clicks on the icon from the
-     * user interacting in the grid.
-     *
-     * @implNote
+     * user interacting in the grid.<br>
      * The area in which will be set to define whether this icon is
      * contained is this area is implementation-dependent, that is each
-     * class implementing {@link Icon} may define a different area.
+     * class implementing Icon may define a different area.
      *
      * @param x the X-coordinate
      * @param y the Y-coordinate

--- a/src/ispd/gui/iconico/grade/Machine.java
+++ b/src/ispd/gui/iconico/grade/Machine.java
@@ -170,8 +170,29 @@ public class Machine extends VertexGridItem {
         }
 
         this.configured = !(this.master &&
-                ("---".equals(this.schedulingAlgorithm) ||
-                        "---".equals(this.vmmAllocationPolicy)));
+                            ("---".equals(this.schedulingAlgorithm) ||
+                             "---".equals(this.vmmAllocationPolicy)));
+    }
+
+    /**
+     * It describes this machine's role relative if it is a
+     * master.
+     *
+     * @param translator the translator containing the
+     *                   translated messages
+     * @return the described machine role
+     */
+    private String describeRole(
+            final ResourceBundle translator) {
+        if (!this.master) {
+            return "<br>" + translator.getString("Slave");
+        }
+
+        return "<br>%s<br>%s: %s".formatted(
+                translator.getString("Master"),
+                translator.getString("Scheduling algorithm"),
+                this.schedulingAlgorithm
+        );
     }
 
     /**
@@ -191,21 +212,18 @@ public class Machine extends VertexGridItem {
     }
 
     /**
-     * It calculates the <strong>connected</strong> outbound
-     * nodes starting from the given <em>grid item</em>. Further,
-     * those nodes found in the process are added into the
-     * given outbound connected nodes set.
+     * It calculates the <strong>connected</strong> outbound nodes starting
+     * from the given <em>grid item</em>. Further, those nodes found in the
+     * process are added into the given outbound connected nodes set.<br>
+     * Pre-conditions: <ol>
+     * <li>It is assumed that the given grid item is <b>not null</b>.
+     * Otherwise, a {@link NullPointerException} will be thrown.</li>
+     * <li>It is assumed that the given outbound connected nodes set is
+     * <b>not null</b>. Otherwise, a {@link NullPointerException} will be
+     * thrown.</li> </ol>
      *
      * @param gridItem               the grid item
-     * @param outboundConnectedNodes the outbound connected
-     *                               nodes
-     * @implNote Pre-conditions:
-     *         1. It is supposed that the given grid item is
-     *         <strong>not null</strong>. Otherwise, a
-     *         {@link NullPointerException} will be thrown.
-     *         2. It is supposed that the given outbound
-     *         connected nodes set is <strong>not null</strong>.
-     *         Otherwise, a {@link NullPointerException} will be thrown.
+     * @param outboundConnectedNodes the outbound connected nodes
      */
     private void calculateConnectedOutboundNodes(
             final GridItem gridItem,
@@ -220,7 +238,7 @@ public class Machine extends VertexGridItem {
             /* If the destination item is a Cluster or */
             /* a Machine, then just add them */
             if (destinationItem instanceof Cluster ||
-                    destinationItem instanceof Machine) {
+                destinationItem instanceof Machine) {
                 outboundConnectedNodes.add(destinationItem);
             }
             /* If the destination item is an Internet, then */
@@ -256,18 +274,16 @@ public class Machine extends VertexGridItem {
      * It calculates the <strong>connected</strong> inbound
      * nodes ending at the given <em>grid item</em>. Further,
      * those nodes found in the process are added into the
-     * inbound connected nodes set.
+     * inbound connected nodes set.<br>
+     * Preconditions: <ol>
+     * <li>It is assumed that the given grid item is <b>not null</b>.
+     * Otherwise, a {@link NullPointerException} will be thrown.</li>
+     * <li>It is assumed that the given inbound connected nodes set is <b>not
+     * null</b>. Otherwise, {@link NullPointerException} will be thrown.</li>
+     * </ol>
      *
      * @param gridItem              the grid item
-     * @param inboundConnectedNodes the inbound connected
-     *                              nodes
-     * @implNote Pre-conditions:
-     *         1. It is supposed that the given grid item is
-     *         <strong>not null</strong>. Otherwise, a
-     *         {@link NullPointerException} will be thrown.
-     *         2. It is supposed that the given inbound connected
-     *         nodes set is <strong>not null</strong>.
-     *         Otherwise, {@link NullPointerException} will be thrown.
+     * @param inboundConnectedNodes the inbound connected nodes
      */
     private void calculateConnectedInboundNodes(
             final GridItem gridItem,
@@ -280,7 +296,7 @@ public class Machine extends VertexGridItem {
             /* If the source item is a Cluster or a Machine, */
             /* then just add them */
             if (sourceItem instanceof Cluster ||
-                    sourceItem instanceof Machine) {
+                sourceItem instanceof Machine) {
                 inboundConnectedNodes.add(sourceItem);
             }
             /* If the source item is an Internet, then add */
@@ -314,20 +330,21 @@ public class Machine extends VertexGridItem {
         return schedulableItems;
     }
 
+    /* Getters & Setters */
+
     /**
-     * It calculates the <strong>connected</strong> schedulable
-     * nodes. Further, those nodes found in the process are
-     * added into the schedulable items list.
+     * It calculates the <strong>connected</strong> schedulable nodes.
+     * Further, those nodes found in the process are added into the
+     * schedulable items list.<br>
+     * Preconditions: <ol>
+     * <li>It is assumed that the given grid item is <b>not null</b>.
+     * Otherwise, a {@link NullPointerException} will be thrown.</li>
+     * <li>It is assumed that the given schedulable items list is <b>not
+     * null</b>. Otherwise, {@link NullPointerException} will be thrown.</li>
+     * </ol>
      *
      * @param gridItem         the grid item
      * @param schedulableItems the schedulable items
-     * @implNote Pre-conditions:
-     *         1. It is supposed that the given grid item is
-     *         <strong>not null</strong>. Otherwise, a
-     *         {@link NullPointerException} will be thrown.
-     *         2. It is supposed that the given schedulable items
-     *         list is <strong>not null</strong>. Otherwise,
-     *         {@link NullPointerException} will be thrown.
      */
     private void calculateConnectedSchedulableNodes(
             final GridItem gridItem,
@@ -340,7 +357,7 @@ public class Machine extends VertexGridItem {
             /* If the destination item is a Cluster or is */
             /* a Machine, then just add them */
             if (destinationItem instanceof Cluster ||
-                    destinationItem instanceof Machine) {
+                destinationItem instanceof Machine) {
                 /* Prevent duplicates */
                 if (!schedulableItems.contains(destinationItem))
                     schedulableItems.add(destinationItem);
@@ -353,8 +370,6 @@ public class Machine extends VertexGridItem {
             }
         }
     }
-
-    /* Getters & Setters */
 
     /**
      * Returns the computational power.
@@ -376,7 +391,6 @@ public class Machine extends VertexGridItem {
         this.computationalPower = computationalPower;
         this.checkConfiguration();
     }
-
 
     /**
      * Returns the load factor.
@@ -529,13 +543,12 @@ public class Machine extends VertexGridItem {
         this.coreCount = coreCount;
     }
 
-
     /**
      * Returns {@code true} since this machine is master.
      * Otherwise, {@code false} is returned.
      *
      * @return {@code true} since this machine is master;
-     *         otherwise, {@code false} is returned.
+     * otherwise, {@code false} is returned.
      */
     public Boolean isMaster() {
         return this.master;
@@ -621,6 +634,8 @@ public class Machine extends VertexGridItem {
         return this.slaves;
     }
 
+    /* getImage */
+
     /**
      * It sets the list of slaves.
      *
@@ -630,7 +645,7 @@ public class Machine extends VertexGridItem {
         this.slaves = slaves;
     }
 
-    /* getImage */
+    /* toString */
 
     /**
      * Returns the machine icon image.
@@ -642,8 +657,6 @@ public class Machine extends VertexGridItem {
         return DesenhoGrade.machineIcon;
     }
 
-    /* toString */
-
     /**
      * Returns the string representation of {@link Machine}.
      *
@@ -652,27 +665,6 @@ public class Machine extends VertexGridItem {
     @Override
     public String toString() {
         return "id: " + this.id.getGlobalId()
-                + " " + this.id.getName();
-    }
-
-    /**
-     * It describes this machine's role relative if it is a
-     * master.
-     *
-     * @param translator the translator containing the
-     *                   translated messages
-     * @return the described machine role
-     */
-    private String describeRole(
-            final ResourceBundle translator) {
-        if (!this.master) {
-            return "<br>" + translator.getString("Slave");
-        }
-
-        return "<br>%s<br>%s: %s".formatted(
-                translator.getString("Master"),
-                translator.getString("Scheduling algorithm"),
-                this.schedulingAlgorithm
-        );
+               + " " + this.id.getName();
     }
 }

--- a/src/ispd/gui/iconico/grade/VertexGridItem.java
+++ b/src/ispd/gui/iconico/grade/VertexGridItem.java
@@ -40,6 +40,28 @@ import java.util.Set;
     /**
      * Constructor of {@link VertexGridItem} which specifies
      * the local, global and name identifiers, as well as,
+     * the X and Y coordinates.
+     *
+     * @param localId  the local id
+     * @param globalId the global id
+     * @param name     the name
+     * @param x        the vertex grid item x-coordinate
+     *                 in cartesian coordinates
+     * @param y        the vertex grid item y-coordinate
+     *                 in cartesian coordinates
+     */
+    public VertexGridItem(
+            final int localId,
+            final int globalId,
+            final String name,
+            final Integer x,
+            final Integer y) {
+        this(localId, globalId, name, x, y, false);
+    }
+
+    /**
+     * Constructor of {@link VertexGridItem} which specifies
+     * the local, global and name identifiers, as well as,
      * the X and Y coordinates and whether is selected.
      *
      * @param localId  the local id
@@ -62,28 +84,6 @@ import java.util.Set;
         this.id = new GridItemIdentifier(localId, globalId, name + globalId);
         this.inboundConnections = new HashSet<>();
         this.outboundConnections = new HashSet<>();
-    }
-
-    /**
-     * Constructor of {@link VertexGridItem} which specifies
-     * the local, global and name identifiers, as well as,
-     * the X and Y coordinates.
-     *
-     * @param localId  the local id
-     * @param globalId the global id
-     * @param name     the name
-     * @param x        the vertex grid item x-coordinate
-     *                 in cartesian coordinates
-     * @param y        the vertex grid item y-coordinate
-     *                 in cartesian coordinates
-     */
-    public VertexGridItem(
-            final int localId,
-            final int globalId,
-            final String name,
-            final Integer x,
-            final Integer y) {
-        this(localId, globalId, name, x, y, false);
     }
 
     /**
@@ -116,13 +116,12 @@ import java.util.Set;
     }
 
     /**
-     * Returns this grid item offset.
+     * Returns this grid item offset.<br>
+     * The offset represents a <i>margin of error</i> to state whether this
+     * grid item is contained at a given x-coordinate and y-coordinate in
+     * {@link #contains(int, int)} method.
      *
      * @return this grid item offset
-     * @apiNote The offset represents a <em>margin of error</em> to
-     *         state whether this grid item is contained at a given
-     *         x-coordinate and y-coordinate in {@link #contains(int, int)}
-     *         method.
      */
     protected int getOffset() {
         return 17;
@@ -137,14 +136,14 @@ import java.util.Set;
      * @param x the X-coordinate
      * @param y the Y-coordinate
      * @return {@code true} if this grid item is contained at
-     *         the given coordinates; otherwise {@code false}
-     *         is returned.
+     * the given coordinates; otherwise {@code false}
+     * is returned.
      */
     @Override
     public boolean contains(final int x, final int y) {
         final var offset = this.getOffset();
         return (x > this.getX() - offset && x < this.getX() + offset) &&
-                (y > this.getY() - offset && y < this.getY() + offset);
+               (y > this.getY() - offset && y < this.getY() + offset);
     }
 
     /**

--- a/src/ispd/motor/falhas/FState.java
+++ b/src/ispd/motor/falhas/FState.java
@@ -1,84 +1,62 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
 package ispd.motor.falhas;
 
-import ispd.motor.*;
+import ispd.motor.ProgressoSimulacao;
 import ispd.motor.filas.RedeDeFilasCloud;
 import ispd.motor.filas.servidores.CS_Processamento;
 import ispd.motor.filas.servidores.implementacao.CS_VirtualMac;
 
-import java.util.ArrayList;
 import javax.swing.JOptionPane;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.Random;
 
-/**
- *
- * @author Fabio Amorim da Silva
- * @param redeDeFilas
- * @param janela
- * 
- */
-public class FState{
-    
+public class FState {
     private ArrayList<CS_VirtualMac> VMs;
     private LinkedList<CS_Processamento> PMs;
-    
-    public void FIState1(ProgressoSimulacao janela, RedeDeFilasCloud redeDeFilas){
 
-    //Mensagens com a inserção de falha
-     JOptionPane.showMessageDialog(null, "State transmission failure detected.");
-     janela.println("State transmission fault created.");
-     janela.println("->");
-     
-     //Criação de filas vazias para armazenamento das máquinas antes da falha
-        
-     //Processo de falha e tratamento
-     if(redeDeFilas.getVMs() == null){
+    public void FIState1(
+            ProgressoSimulacao janela, RedeDeFilasCloud redeDeFilas) {
+
+        //Mensagens com a inserção de falha
+        JOptionPane.showMessageDialog(null, "State transmission failure " +
+                                            "detected.");
+        janela.println("State transmission fault created.");
+        janela.println("->");
+
+        //Criação de filas vazias para armazenamento das máquinas antes da falha
+
+        //Processo de falha e tratamento
+        if (redeDeFilas.getVMs() == null) {
             System.out.println("---------------------------------------");
             System.out.println("Rede de filas é nula.");
-        
-     }// if(redeDeFilas.getVMs() == null)
-     else if(redeDeFilas.getVMs() != null){
-        
-     //Criação de números aleatórios para impedir o estado de transmissão
-     Random cloudMachines    = new Random(); //Máquinas da nuvem
-     double machineDown = cloudMachines.nextInt(redeDeFilas.getMaquinasCloud().size());
-     
-     
-     //Máquina desligada para impedir que a transmissão seja feita   
-     machineDown = ispd.motor.filas.servidores.implementacao.CS_MaquinaCloud.DESLIGADO;
-     
-     //Nova máquina para ser replicada
-     double newMachine = machineDown;
-     
-     //Número de VMs na simulação
-     double machineNumber = redeDeFilas.getMaquinasCloud().size();
-     
-     //Método de recuperação - Replicação
-        for(int i = 0; i < machineNumber; i++){
 
-           if(machineDown == 2){
+        }// if(redeDeFilas.getVMs() == null)
+        else if (redeDeFilas.getVMs() != null) {
+            //Criação de números aleatórios para impedir o estado de transmissão
+            Random cloudMachines = new Random(); //Máquinas da nuvem
+            double machineDown =
+                    cloudMachines.nextInt(redeDeFilas.getMaquinasCloud().size());
 
-               machineDown = newMachine;
-               newMachine = ispd.motor.filas.servidores.implementacao.CS_MaquinaCloud.DESLIGADO;
+            //Máquina desligada para impedir que a transmissão seja feita
+            machineDown =
+                    ispd.motor.filas.servidores.implementacao.CS_MaquinaCloud.DESLIGADO;
 
-           }else {
-           
-              janela.println("Nenhuma máquina com falha encontrada!");
-           
-           }
+            //Nova máquina para ser replicada
+            double newMachine = machineDown;
 
+            //Número de VMs na simulação
+            double machineNumber = redeDeFilas.getMaquinasCloud().size();
 
+            //Método de recuperação - Replicação
+            for (int i = 0; i < machineNumber; i++) {
+                if (machineDown == 2) {
+                    machineDown = newMachine;
+                    newMachine =
+                            ispd.motor.filas.servidores.implementacao.CS_MaquinaCloud.DESLIGADO;
+                } else {
+                    janela.println("Nenhuma máquina com falha encontrada!");
+                }
+            }
         }
-     
-     
-      } //else if(redeDeFilas.getVMs() != null)
-       
-    }// Fim falha de estado de transmissão
-    
+    }
 }

--- a/src/ispd/motor/workload/impl/task/TraceTaskBuilder.java
+++ b/src/ispd/motor/workload/impl/task/TraceTaskBuilder.java
@@ -35,16 +35,16 @@ public class TraceTaskBuilder extends TaskBuilder {
     /**
      * Pops a {@link TraceTaskInfo} object from the inner list
      * {@link #traceTaskInfos} and converts it into a task originating from
-     * the given {@link CS_Processamento}.
+     * the given {@link CS_Processamento}.<br>
+     * This method can only be called successfully at most {@code n} times,
+     * where {@code n} is the size of the {@link List} this instance was
+     * initialized with.
      *
      * @param master {@link CS_Processamento} that will host the task.
      * @return created {@link Tarefa}.
      * @throws IndexOutOfBoundsException if there are no more usable task
      *                                   information instances in the inner
      *                                   list.
-     * @apiNote this method can only be called successfully at most {@code n}
-     * times, where {@code n} is the size of the {@link List} this instance
-     * was initialized with.
      */
     @Override
     public Tarefa makeTaskFor(final CS_Processamento master) {


### PR DESCRIPTION
Remove "`@apiNote`" and "`@implNote`" tags since they are not recognized as valid tags during generation.
Hunted down invalid javadocs and fixed or purged them.